### PR TITLE
Got rid of manipulation_msgs and household_object_database_msgs

### DIFF
--- a/grasp_execution/CMakeLists.txt
+++ b/grasp_execution/CMakeLists.txt
@@ -94,6 +94,7 @@ add_library(simple_grasp_control_server
 add_dependencies(simple_grasp_control_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_library(simple_grasp_action_server
+  src/GraspStateHelper.cpp
   src/GraspEligibilityChecker.cpp
   src/GraspActionServer.cpp
   src/SimpleGraspActionServer.cpp

--- a/grasp_execution/include/grasp_execution/GraspEligibilityChecker.h
+++ b/grasp_execution/include/grasp_execution/GraspEligibilityChecker.h
@@ -9,13 +9,13 @@ namespace grasp_execution
 
 /**
  * Class that can be used to check for eligibility of grasping and un-grasping actions.
- * 
+ *
  * The action message to be checked is of type grasp_execution_msgs/Grasp.action. Please also refer
  * to this message for documentation about the inputs / outputs.
  *
  * This class provides the option to subscribe to joint states in order to check eligibility criteria.
  *
- * Different implementations for handling the eligibility checks 
+ * Different implementations for handling the eligibility checks
  * can be achieved by deriving this class.
  * The default implementation in this base class only checks for the end effector pose and
  * ignores the joint states.
@@ -41,7 +41,7 @@ public:
 		const float& _effectorOriAccuracy,
         const float& _jointAnglesAccuracy);
 
-	virtual ~GraspEligibilityChecker(); 
+	virtual ~GraspEligibilityChecker();
 
 
     /**
@@ -50,7 +50,7 @@ public:
      * end effector pose is checked to be as expected.
      */
     virtual bool checksJointStates();
-    
+
     /**
      * Connects subscriber to receive most recent joint states. This only
      * makes sense if checkJointStates() returns true, and if the Grasp actions
@@ -75,18 +75,18 @@ protected:
      *      has to be at to perform the grasp
 	 */
 	bool graspExecutionEligible(const std::string& effectorLinkFrame,
-            const geometry_msgs::PoseStamped& graspPose, 
+            const geometry_msgs::PoseStamped& graspPose,
 			const float& _effectorPosAccuracy,
             const float& _effectorOriAccuracy);
 
     /**
      * Checks for consistency in the grasp goal. In particular, checks
      * whether the JointTrajectory (grasp_trajectory) relating to the grasp
-     * conforms to the fields in the manipulation_msgs::Grasp, i.e. the
+     * conforms to the fields in the moveit_msgs::Grasp, i.e. the
      * last trajectory point has to be the same as the
-     * manipulation_msgs::Grasp::(pre_)grasp_posture.
+     * moveit_msgs::Grasp::(pre_)grasp_posture.
      * \param useJointAnglesAccuracy the tolerance to use for comparing joint states
-     */   
+     */
     bool goalJointStatesConsistent(const GraspGoalT& graspGoal, const float useJointAnglesAccuracy) const;
 
  	// default tolerance for the effector target pose and actual effector pose to be
@@ -96,7 +96,7 @@ protected:
  	// default tolerance for the effector target orientation and actual effector orientation to be
 	// similar enough to accept a grasp action (in rad).
 	float effectorOriAccuracy;
-	
+
     // default tolerance for the joints (in rad) when checking against joint state targets
     float jointAnglesAccuracy;
 

--- a/grasp_execution/include/grasp_execution/SimpleAutomatedGraspFromFile.h
+++ b/grasp_execution/include/grasp_execution/SimpleAutomatedGraspFromFile.h
@@ -7,7 +7,7 @@ namespace grasp_execution
 {
 
 /**
- * Reads a manipulation_msgs/Grasp.msg from a file and uses this
+ * Reads a moveit_msgs/Grasp.msg from a file and uses this
  * as the result for grasp planning. Only minimal adaptations such as
  * object name are made to the message.
  *
@@ -21,11 +21,11 @@ public:
     virtual ~SimpleAutomatedGraspFromFile();
 
 protected:
-    virtual bool initImpl(); 
+    virtual bool initImpl();
     virtual bool getGrasp(const std::string& object_name, bool isGrasp, grasp_execution_msgs::GraspGoal& graspGoal);
 
 private:
-    std::string filename; 
+    std::string filename;
 };
 
 }  // namespace

--- a/grasp_execution/include/grasp_execution/SimpleAutomatedGraspOnlinePlanning.h
+++ b/grasp_execution/include/grasp_execution/SimpleAutomatedGraspOnlinePlanning.h
@@ -44,7 +44,7 @@ public:
     virtual ~SimpleAutomatedGraspOnlinePlanning();
 
 protected:
-    virtual bool initImpl(); 
+    virtual bool initImpl();
     virtual bool getGrasp(const std::string& object_name, bool isGrasp, grasp_execution_msgs::GraspGoal& graspGoal);
 
 private:
@@ -54,16 +54,16 @@ private:
     std::vector<std::string> robotFingerJointNames;
     std::string objectFilename;
     std::string tableFilename;
-        
+
     geometry_msgs::Pose objectPose;
-   
+
     // only kept so it can be used for following un-grasp
-    manipulation_msgs::Grasp lastPlanResult;
+    moveit_msgs::Grasp lastPlanResult;
     std::string lastPlanObject;
-    
-    int objectID; 
-    
-    grasp_planning_graspit_ros::EigenGraspPlannerClient graspitClient; 
+
+    int objectID;
+
+    grasp_planning_graspit_ros::EigenGraspPlannerClient graspitClient;
 
 };
 

--- a/grasp_execution/include/grasp_execution/SimpleGraspActionServer.h
+++ b/grasp_execution/include/grasp_execution/SimpleGraspActionServer.h
@@ -13,8 +13,8 @@ namespace grasp_execution
  * This implementation of GraspActionServer simply forwards the target JointState
  * as a grasp_execution_msgs/GraspControl.action. It does not support gripper translation
  * (approach / retreat) and is therefore a very simple implementation. All it does
- * is set the gripper to the manipulation_msgs::Grasp::grasp_posture for a grasp,
- * and to manipulation_msgs::Grasp::pre_grasp_posture for an ungrasp.
+ * is set the gripper to the moveit_msgs::Grasp::grasp_posture for a grasp,
+ * and to moveit_msgs::Grasp::pre_grasp_posture for an ungrasp.
  *
  * \author Jennifer Buehler
  * \date March 2016
@@ -25,7 +25,7 @@ protected:
     typedef actionlib::SimpleActionClient<grasp_execution_msgs::GraspControlAction> GraspControlActionClientT;
     typedef grasp_execution_msgs::GraspControlFeedbackConstPtr GraspControlFeedbackConstPtrT;
     typedef grasp_execution_msgs::GraspControlResultConstPtr GraspControlResultConstPtrT;
-    
+
 public:
 
     /**

--- a/grasp_execution/src/GraspActionServer.cpp
+++ b/grasp_execution/src/GraspActionServer.cpp
@@ -15,20 +15,22 @@ bool GraspActionServer::canAccept(const ActionGoalHandleT& goal)
     GoalConstPtrT graspGoal = goal.getGoal();
 
     if (graspGoal->gripper_approach_trajectory.points.empty() 
-        && (graspGoal->grasp.grasp.approach.desired_distance > 1e-03))
+        && (graspGoal->grasp.grasp.pre_grasp_approach.desired_distance > 1e-03))
     {
         ROS_WARN_STREAM("GraspActionServer: Inconsistency in grasp action. "<<
-            " The grasp has a desired distance "<<graspGoal->grasp.grasp.approach.desired_distance<<
+            " The grasp has a desired distance "
+            << graspGoal->grasp.grasp.pre_grasp_approach.desired_distance <<
             " for the approach, but no trajectory is specified. The approach "<<
             " specification may do nothing in the action.");
     }
 
     if (graspGoal->gripper_retreat_trajectory.points.empty() 
-        && (graspGoal->grasp.grasp.retreat.desired_distance > 1e-03))
+        && (graspGoal->grasp.grasp.post_grasp_retreat.desired_distance > 1e-03))
     {
         ROS_WARN_STREAM("GraspActionServer: Inconsistency in grasp action. "<<
-            " The grasp has a desired distance "<<graspGoal->grasp.grasp.retreat.desired_distance<<
-            " for the retreat, but no trajectory is specified. The retreat "<<
+            " The grasp has a desired distance "
+            << graspGoal->grasp.grasp.post_grasp_retreat.desired_distance <<
+            " for the retreat, but no trajectory is specified. The retreat " <<
             " specification may do nothing in the action.");
     }
 

--- a/grasp_execution/src/GraspStateHelper.cpp
+++ b/grasp_execution/src/GraspStateHelper.cpp
@@ -1,0 +1,16 @@
+#include "GraspStateHelper.h"
+
+int grasp_execution::getStateFromTrajectory(const trajectory_msgs::JointTrajectory &jt,
+                            sensor_msgs::JointState &js)
+{
+  js.header = jt.header;
+  js.name = jt.joint_names;
+  if (jt.points.empty())
+  {
+    return -1;
+  }
+  js.position = jt.points.front().positions;
+  if (jt.points.size() != 1)
+    return 1;
+  return 0;
+}

--- a/grasp_execution/src/GraspStateHelper.h
+++ b/grasp_execution/src/GraspStateHelper.h
@@ -1,0 +1,21 @@
+#ifndef GRASP_STATE_HELPER_H
+#define GRASP_STATE_HELPER_H
+
+#include <sensor_msgs/JointState.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+namespace grasp_execution
+{
+
+// Helper for intermediately fixing the changeover from sensor_msgs/JointState
+// to trajectory_msgs/JointTrajectory: writes the first joint trajectory point
+// as joint state.
+// Returns 0 on success, -1 if there is no JointTrajectoryPoint, and 1 if
+// there are several points (a warning, because only the first is used and
+// the rest is ignored).
+int getStateFromTrajectory(const trajectory_msgs::JointTrajectory &jt,
+                            sensor_msgs::JointState &js);
+
+}  // namespace
+
+#endif  // GRASP_STATE_HELPER_H

--- a/grasp_execution/src/SimpleAutomatedGraspFromFile.cpp
+++ b/grasp_execution/src/SimpleAutomatedGraspFromFile.cpp
@@ -1,7 +1,7 @@
 #include <grasp_execution/SimpleAutomatedGraspFromFile.h>
 #include <grasp_execution/SimpleGraspGenerator.h>
 #include <convenience_ros_functions/ROSFunctions.h>
-#include <manipulation_msgs/Grasp.h>
+#include <moveit_msgs/Grasp.h>
 
 using grasp_execution::SimpleAutomatedGraspFromFile;
 
@@ -18,7 +18,7 @@ bool SimpleAutomatedGraspFromFile::initImpl()
 
 bool SimpleAutomatedGraspFromFile::getGrasp(const std::string& object_name, bool isGrasp, grasp_execution_msgs::GraspGoal& graspGoal)
 {
-    manipulation_msgs::Grasp grasp;
+    moveit_msgs::Grasp grasp;
     if (!ROSFunctions::readFromFile(filename,grasp,true))
     {
         ROS_ERROR_STREAM("Could not read grasp from file "<<filename);
@@ -28,7 +28,7 @@ bool SimpleAutomatedGraspFromFile::getGrasp(const std::string& object_name, bool
     grasp.grasp_pose.header.frame_id=object_name;
     ROS_INFO_STREAM("Read grasp from file: "<<grasp);
 
-    // ROS_INFO_STREAM("generated manipulation_msgs::Grasp: "<<std::endl<<mgrasp);
+    // ROS_INFO_STREAM("generated moveit_msgs::Grasp: "<<std::endl<<mgrasp);
     std::string effector_link = jointsManager->getEffectorLink();
     grasp_execution::SimpleGraspGenerator::generateSimpleGraspGoal(effector_link,
         grasp,0, isGrasp, graspGoal);

--- a/grasp_execution/src/SimpleAutomatedGraspFromTop.cpp
+++ b/grasp_execution/src/SimpleAutomatedGraspFromTop.cpp
@@ -36,7 +36,7 @@ bool SimpleAutomatedGraspFromTop::getGrasp(const std::string& object_name, bool 
     std::string arm_base_link = jointsManager->getArmLinks().front();
     std::string effector_link = jointsManager->getEffectorLink();
     
-    manipulation_msgs::Grasp mgrasp;
+    moveit_msgs::Grasp mgrasp;
     bool genGraspSuccess = grasp_execution::SimpleGraspGenerator::generateSimpleGraspFromTop(
         gripperJoints,
         arm_base_link,
@@ -54,7 +54,7 @@ bool SimpleAutomatedGraspFromTop::getGrasp(const std::string& object_name, bool 
         return false;
     }
 
-    // ROS_INFO_STREAM("generated manipulation_msgs::Grasp: "<<std::endl<<mgrasp);
+    // ROS_INFO_STREAM("generated moveit_msgs::Grasp: "<<std::endl<<mgrasp);
     grasp_execution::SimpleGraspGenerator::generateSimpleGraspGoal(effector_link,
         mgrasp,0, isGrasp, graspGoal);
 

--- a/grasp_execution/src/SimpleAutomatedGraspOnlinePlanning.cpp
+++ b/grasp_execution/src/SimpleAutomatedGraspOnlinePlanning.cpp
@@ -1,7 +1,7 @@
 #include <grasp_execution/SimpleAutomatedGraspOnlinePlanning.h>
 #include <grasp_execution/SimpleGraspGenerator.h>
 #include <convenience_ros_functions/ROSFunctions.h>
-#include <manipulation_msgs/Grasp.h>
+#include <moveit_msgs/Grasp.h>
 
 using grasp_execution::SimpleAutomatedGraspOnlinePlanning;
 
@@ -82,14 +82,15 @@ bool SimpleAutomatedGraspOnlinePlanning::initImpl()
 
 bool SimpleAutomatedGraspOnlinePlanning::getGrasp(const std::string& object_name, bool isGrasp, grasp_execution_msgs::GraspGoal& graspGoal)
 {
-    ROS_INFO_STREAM("SimpleAutomatedGraspOnlinePlanning: Grasping for object "<<object_name);
+    ROS_INFO_STREAM("SimpleAutomatedGraspOnlinePlanning: Grasping for object "
+                    << object_name);
         
-    manipulation_msgs::Grasp grasp;
+    moveit_msgs::Grasp grasp;
 
     if (isGrasp)
     {   // do whole grasp planning
-        std::vector<manipulation_msgs::Grasp> graspResults;
-        int planRet = graspitClient.plan(robotName,objectID, NULL, resultsDirectory, graspResults);
+        std::vector<moveit_msgs::Grasp> graspResults;
+        int planRet = graspitClient.plan(robotName, objectID, NULL, resultsDirectory, graspResults);
         if (planRet != 0)
         {
             ROS_ERROR_STREAM("SimpleAutomatedGraspOnlinePlanning: Could not plan the grasp for object "<<object_name);
@@ -114,7 +115,7 @@ bool SimpleAutomatedGraspOnlinePlanning::getGrasp(const std::string& object_name
         }
         grasp=lastPlanResult;
     }
-    // ROS_INFO_STREAM("generated manipulation_msgs::Grasp: "<<std::endl<<mgrasp);
+    // ROS_INFO_STREAM("generated moveit_msgs::Grasp: "<<std::endl<<mgrasp);
     std::string effector_link = jointsManager->getEffectorLink();
     grasp_execution::SimpleGraspGenerator::generateSimpleGraspGoal(effector_link,
         grasp,0, isGrasp, graspGoal);

--- a/grasp_execution/src/SimpleGraspActionServer.cpp
+++ b/grasp_execution/src/SimpleGraspActionServer.cpp
@@ -1,4 +1,5 @@
 #include <grasp_execution/SimpleGraspActionServer.h>
+#include "GraspStateHelper.h"
 
 using grasp_execution::SimpleGraspActionServer;
 
@@ -30,12 +31,27 @@ void SimpleGraspActionServer::shutdownImpl(){
 
 void SimpleGraspActionServer::actionCallbackImpl(const ActionGoalHandleT& goal)
 {
-    const manipulation_msgs::Grasp& grasp = goal.getGoal()->grasp.grasp;
+    const moveit_msgs::Grasp& grasp = goal.getGoal()->grasp.grasp;
     if (goal.getGoal()->is_grasp){
-        const sensor_msgs::JointState& graspPosture=grasp.grasp_posture;
+
+        sensor_msgs::JointState graspPosture;
+        int ret = getStateFromTrajectory(grasp.grasp_posture, graspPosture);
+        if (ret != 0)
+        {
+          ROS_ERROR_STREAM("Could not get JointState from JointTrajectory, "
+           << "return code " << ret << ". Won't execute grasp action.");
+          return;
+        }
         this->startGraspExecution(graspPosture);
     }else{ 
-        const sensor_msgs::JointState& graspPosture=grasp.pre_grasp_posture;    
+        sensor_msgs::JointState graspPosture;
+        int ret = getStateFromTrajectory(grasp.pre_grasp_posture, graspPosture);
+        if (ret != 0)
+        {
+          ROS_ERROR_STREAM("Could not get JointState from JointTrajectory, "
+           << "return code " << ret << ". Won't execute grasp action.");
+          return;
+        }
         this->startGraspExecution(graspPosture);
     }
 }

--- a/grasp_execution/src/simple_automated_grasp_execution.cpp
+++ b/grasp_execution/src/simple_automated_grasp_execution.cpp
@@ -104,7 +104,6 @@ int main(int argc, char** argv)
 
         priv.getParam("results_directory",RESULTS_DIRECTORY);
     }
-
  
     grasp_execution::SimpleAutomatedGraspExecution * graspExe;
     if (RUN_TYPE == 1) graspExe = new grasp_execution::SimpleAutomatedGraspFromTop();

--- a/grasp_execution/test/simple_grasp_action_client.cpp
+++ b/grasp_execution/test/simple_grasp_action_client.cpp
@@ -48,11 +48,12 @@ int main(int argc, char** argv)
         ROS_ERROR("Object name required!");
         return 0;
     } 
+    
     std::string OBJECT_NAME;
-	priv.param<std::string>("object_name", OBJECT_NAME, OBJECT_NAME);
+	  priv.param<std::string>("object_name", OBJECT_NAME, OBJECT_NAME);
 
-	std::string REQUEST_OBJECTS_TOPIC="world/request_object";
-	priv.param<std::string>("request_object_service_topic", REQUEST_OBJECTS_TOPIC, REQUEST_OBJECTS_TOPIC);
+	  std::string REQUEST_OBJECTS_TOPIC="world/request_object";
+	  priv.param<std::string>("request_object_service_topic", REQUEST_OBJECTS_TOPIC, REQUEST_OBJECTS_TOPIC);
 
     std::string ROBOT_NAMESPACE;
     if (!priv.hasParam("robot_namespace"))
@@ -60,7 +61,7 @@ int main(int argc, char** argv)
         ROS_ERROR("Node requires private parameter 'robot_namespace'");
         return 1;
     }
-	priv.param<std::string>("robot_namespace", ROBOT_NAMESPACE, ROBOT_NAMESPACE);
+	  priv.param<std::string>("robot_namespace", ROBOT_NAMESPACE, ROBOT_NAMESPACE);
 
     arm_components_name_manager::ArmComponentsNameManager jointsManager(ROBOT_NAMESPACE, false);
     double maxWait=5;
@@ -75,22 +76,22 @@ int main(int argc, char** argv)
     std::string effector_link = jointsManager.getEffectorLink();
  
     bool GRASPING=true;
-	priv.param<bool>("grasping_action", GRASPING, GRASPING);
+  	priv.param<bool>("grasping_action", GRASPING, GRASPING);
     
     double OPEN_ANGLES=0.05;
-	priv.param<double>("open_angles", OPEN_ANGLES, OPEN_ANGLES);
+  	priv.param<double>("open_angles", OPEN_ANGLES, OPEN_ANGLES);
     double CLOSE_ANGLES=0.7;
-	priv.param<double>("close_angles", CLOSE_ANGLES, CLOSE_ANGLES);
+  	priv.param<double>("close_angles", CLOSE_ANGLES, CLOSE_ANGLES);
 
     std::string GRASP_ACTION_TOPIC = "/grasp_action";
-	priv.param<std::string>("grasp_action_topic", GRASP_ACTION_TOPIC, GRASP_ACTION_TOPIC);
+  	priv.param<std::string>("grasp_action_topic", GRASP_ACTION_TOPIC, GRASP_ACTION_TOPIC);
 
     double EFF_POS_TOL;
-	priv.param<double>("effector_pos_tolerance", EFF_POS_TOL, EFF_POS_TOL);
+  	priv.param<double>("effector_pos_tolerance", EFF_POS_TOL, EFF_POS_TOL);
     double EFF_ORI_TOL;
-	priv.param<double>("effector_ori_tolerance", EFF_ORI_TOL, EFF_ORI_TOL);
+  	priv.param<double>("effector_ori_tolerance", EFF_ORI_TOL, EFF_ORI_TOL);
     double JOINT_ANGLE_TOL;
-	priv.param<double>("joint_angle_tolerance", JOINT_ANGLE_TOL, JOINT_ANGLE_TOL);
+  	priv.param<double>("joint_angle_tolerance", JOINT_ANGLE_TOL, JOINT_ANGLE_TOL);
         
     object_msgs::Object obj;
    
@@ -128,7 +129,7 @@ int main(int argc, char** argv)
     currEffPos.header.frame_id=object_frame_id;
     ROS_INFO_STREAM("Effector currEffPos pose: "<<currEffPos);
     
-    manipulation_msgs::Grasp mgrasp;
+    moveit_msgs::Grasp mgrasp;
     bool genGraspSuccess = grasp_execution::SimpleGraspGenerator::generateSimpleGraspFromTop(
         gripperJoints,
         arm_base_frame,
@@ -145,11 +146,10 @@ int main(int argc, char** argv)
         ROS_ERROR("Could not generate grasp");
         return 0;
     }
-    // ROS_INFO_STREAM("generated manipulation_msgs::Grasp: "<<std::endl<<mgrasp);
+    // ROS_INFO_STREAM("generated moveit_msgs::Grasp: "<<std::endl<<mgrasp);
 
     // overwrite grasp pose with current end effector pose
     mgrasp.grasp_pose = currEffPos;
-
 
     grasp_execution_msgs::GraspGoal graspGoal;
     bool isGrasp = true;
@@ -161,9 +161,6 @@ int main(int argc, char** argv)
     
     ROS_INFO_STREAM("generated grasp_execution_msgs::Grasp: "<<std::endl<<graspGoal);
 
-  
-
-
     // create the action client
     // true causes the client to spin its own thread
     actionlib::SimpleActionClient<grasp_execution_msgs::GraspAction> ac(GRASP_ACTION_TOPIC, true);
@@ -173,13 +170,8 @@ int main(int argc, char** argv)
     ac.waitForServer(); //will wait for infinite time
     ROS_INFO("Action server started.");
 
-
     ROS_INFO("Now sending goal");
     ac.sendGoal(graspGoal);
-
-
-
-
 
     //wait for the action to return
     bool finished_before_timeout = ac.waitForResult(ros::Duration(15.0));
@@ -190,7 +182,10 @@ int main(int argc, char** argv)
         ROS_INFO("Action finished: %s",state.toString().c_str());
     }
     else
+    {
         ROS_INFO("Action did not finish before the time out.");
+    }
 
+    ROS_INFO("Bye bye");
     return 0;
 }

--- a/grasp_execution/test/test_grasp.launch
+++ b/grasp_execution/test/test_grasp.launch
@@ -21,7 +21,7 @@
     <arg name="open_angles" default="0.05"/>
     
     # angles to set all the finger joints to when un-grasping
-    <arg name="close_angles" default="0.5"/>
+    <arg name="close_angles" default="0.53"/>
         
     # name of the action (topic where it is available)
     <arg name="grasp_action_topic" default="/jaco/grasp_execution/grasp"/>

--- a/grasp_execution_jaco_tutorial/test/GraspCube.cpp
+++ b/grasp_execution_jaco_tutorial/test/GraspCube.cpp
@@ -71,7 +71,6 @@ int main(int argc, char **argv)
         }
     }
 
-
     JacoJointManager joints;
     std::string jointStateTopic(JOINT_STATES_TOPIC);
     std::string jointStatePublishTopic(JOINT_CONTROL_TOPIC);
@@ -103,7 +102,7 @@ int main(int argc, char **argv)
     if (!doUngrasp)
     {
 
-        float grasp_position=0.5;
+        float grasp_position=0.53;
         for (int i = 6; i < idx.size(); ++i) grasp_state.position[idx[i]] = grasp_position;
         ROS_INFO_STREAM("Publishing grasp state" << grasp_state);
         pub.publish(grasp_state);

--- a/grasp_execution_msgs/CMakeLists.txt
+++ b/grasp_execution_msgs/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
   trajectory_msgs
-  manipulation_msgs
+  moveit_msgs
 )
 
 ################################################
@@ -60,7 +60,7 @@ add_action_files(
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES
-  std_msgs sensor_msgs geometry_msgs manipulation_msgs trajectory_msgs
+  std_msgs sensor_msgs geometry_msgs moveit_msgs trajectory_msgs
 )
 
 ###################################
@@ -73,5 +73,5 @@ generate_messages(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-   CATKIN_DEPENDS message_runtime std_msgs sensor_msgs geometry_msgs manipulation_msgs trajectory_msgs
+   CATKIN_DEPENDS message_runtime std_msgs sensor_msgs geometry_msgs moveit_msgs trajectory_msgs
 )

--- a/grasp_execution_msgs/msg/GraspData.msg
+++ b/grasp_execution_msgs/msg/GraspData.msg
@@ -2,7 +2,7 @@
 int32 id
 
 # the grasp to perform
-manipulation_msgs/Grasp grasp 
+moveit_msgs/Grasp grasp 
 
 # the name of the effector link (the one which the grasp refers to).
 # This is needed to check whether according to /tf transforms,

--- a/grasp_execution_msgs/package.xml
+++ b/grasp_execution_msgs/package.xml
@@ -30,12 +30,12 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>manipulation_msgs</build_depend>
+  <build_depend>moveit_msgs</build_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>manipulation_msgs</run_depend>
+  <run_depend>moveit_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This adds support for Melodic, where manipulation_msgs and household_object_database_msgs are deprecated.

See also [graspit pkgs pull request 42](https://github.com/JenniferBuehler/graspit-pkgs/pull/42).